### PR TITLE
detect ajax request and render via renderAjax instead of render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. This project make usage of the [Yii Versioning Strategy](https://github.com/yiisoft/yii2/blob/master/docs/internals/versions.md).
 
+## 1.0.9 (23. October 2018)
+
++ [#20](https://github.com/luyadev/luya-module-contactform/issues/20) Use renderAjax when calling via an ajax request.
+
 ## 1.0.8.1 (4. June 2018)
 
 + [#17](https://github.com/luyadev/luya-module-contactform/issues/17) Fixed bug with wrong declared new line chars.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ## 1.0.9 (23. October 2018)
 
-+ [#20](https://github.com/luyadev/luya-module-contactform/issues/20) Use renderAjax when calling via an ajax request.
++ [#19](https://github.com/luyadev/luya-module-contactform/pull/19) Use renderAjax when calling via an ajax request.
 
 ## 1.0.8.1 (4. June 2018)
 

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -94,11 +94,10 @@ class DefaultController extends \luya\web\Controller
             return $this->renderAjax('index', [
                 'model' => $model
             ]);
-        } else {
-            return $this->render('index', [
-                'model' => $model,
-            ]);
         }
+        return $this->render('index', [
+            'model' => $model,
+        ]);
     }
     
     /**

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -83,7 +83,13 @@ class DefaultController extends \luya\web\Controller
                 }
                 
                 Yii::$app->session->setFlash('contactform_success');
-                
+
+                if (Yii::$app->request->isAjax) {
+                    return $this->renderAjax("index", [
+                        "model" => $model
+                    ]);
+                }
+
                 return $this->refresh();
             } else {
                 throw new InvalidConfigException('Unable to send contact email, maybe the mail component is not setup properly in your config.');

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -89,10 +89,16 @@ class DefaultController extends \luya\web\Controller
                 throw new InvalidConfigException('Unable to send contact email, maybe the mail component is not setup properly in your config.');
             }
         }
-        
-        return $this->render('index', [
-            'model' => $model,
-        ]);
+
+        if (Yii::$app->request->isAjax) {
+            return $this->renderAjax('index', [
+                'model' => $model
+            ]);
+        } else {
+            return $this->render('index', [
+                'model' => $model,
+            ]);
+        }
     }
     
     /**


### PR DESCRIPTION
When calling via an ajax request, the response (form and success) should be rendered with renderAjax.